### PR TITLE
Modify/enable dev route

### DIFF
--- a/server/routes/dev.js
+++ b/server/routes/dev.js
@@ -1,11 +1,13 @@
 import KoaRouter from 'koa-router'
 import controller from '../controllers/dev.js'
-import { SERVER_CONFIG } from '../config/config.js'
+// import { SERVER_CONFIG } from '../config/config.js'
 
 const router = new KoaRouter({ prefix: '/dev' })
 
-if (SERVER_CONFIG.MODE !== 'production') {
-  router.post('/login', controller.fakeFacebookLogin)
-}
+// if (SERVER_CONFIG.MODE !== 'production') {
+//   router.post('/login', controller.fakeFacebookLogin)
+// }
+// It's temporary. Because of TAs' need.
+router.post('/login', controller.fakeFacebookLogin)
 
 export default router

--- a/server/routes/dev.js
+++ b/server/routes/dev.js
@@ -5,7 +5,7 @@ import { SERVER_CONFIG } from '../config/config.js'
 const router = new KoaRouter({ prefix: '/dev' })
 
 if (SERVER_CONFIG.MODE !== 'production') {
-  router.get('/facebook_login', controller.FakeFacebookLogin)
+  router.get('/login', controller.fakeFacebookLogin)
 }
 
 export default router

--- a/server/routes/dev.js
+++ b/server/routes/dev.js
@@ -5,7 +5,7 @@ import { SERVER_CONFIG } from '../config/config.js'
 const router = new KoaRouter({ prefix: '/dev' })
 
 if (SERVER_CONFIG.MODE !== 'production') {
-  router.get('/login', controller.fakeFacebookLogin)
+  router.post('/login', controller.fakeFacebookLogin)
 }
 
 export default router

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -1,6 +1,7 @@
 import KoaRouter from 'koa-router'
 
 import oauthRouter from './authorization.js'
+import devRouter from './dev.js'
 import userRouter from './user.js'
 import goodRouter from './good.js'
 import orderRouter from './order.js'
@@ -10,6 +11,9 @@ import paymentRouter from './payment.js'
 import imageRouter from './image.js'
 
 const router = new KoaRouter({ prefix: '/api' })
+
+// Routes for development needs.
+router.use(devRouter.routes()).use(devRouter.allowedMethods());
 
 // Routes for authorization.
 router.use(oauthRouter.routes()).use(oauthRouter.allowedMethods())


### PR DESCRIPTION
已經把 `dev` 路由重新接回主路由了
`GET /api/dev/facebook_login` 已改成 `POST /api/dev/login`
當 `process.env.NODE_ENV` 不為 `'production'` 時，`POST /api/dev/login` 路由就會啟用