### PR TITLE
Edit domain in development

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,4 +1,4 @@
-const DOMAIN = process.env.DOMAIN || 'ntut.shop'
+const DOMAIN = process.env.DOMAIN || ((process.env.NODE_ENV === 'production') ? 'ntut.shop' : 'localhost')
 const DB_DOMAIN = process.env.DB_DOMAIN || ((process.env.DOCKER_ENV) ? 'mariadb' : DOMAIN)
 
 export let SERVER_CONFIG = {


### PR DESCRIPTION
在開發模式中預設使用 `localhost` 的資料庫。
如需另外指令可使用下列指令設定環境變數 `DB_DOMAIN`
```bash
export DB_DOMAIN='virtualprism.io'
```